### PR TITLE
Update Dockerfile and GitHub Actions to use digests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: Run a one-line script
       run: echo Hello, world!

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 # Dockerfile
-FROM alpine:latest
+FROM index.docker.io/library/alpine:latest@sha256:77726ef6b57ddf65bb551896826ec38bc3e53f75cdde31354fbffb4f25238ebd
 CMD ["echo", "Hello, World!"]


### PR DESCRIPTION
Digests are considered more secure, as it fixes the action to a specific commit

Check out [GitHubs documentation](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) and [the following](https://candrews.integralblue.com/2023/09/always-use-docker-image-digests/) for Dockerfiles

With dependabot enabled, all future updates will be pinned to digests :rocket:

I generated this change using [Frizbee](https://github.com/stacklok/frizbee),
an open source tool that flips tags to digests in Dockerfiles and GitHub Actions.

I created a second PR that add's the Frizbee action to the repository,
which will flip any future tags to digests automatically.
